### PR TITLE
Create lgtm.yml for LGTM.com Python 3 analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup: 
+      version: 3


### PR DESCRIPTION
Hi @narimansafiulin! I noticed that you enabled automated code review by LGTM.com, but that your repository doesn't have any [standard hints](https://lgtm.com/help/lgtm/analysis-faqs#how-python-version-identified) that specify the Python version. As a result, LGTM is analysing your repo as Python 2.7, but you appear to be using Python 3.

This `lgtm.yml` file ([more info here](https://lgtm.com/help/lgtm/lgtm.yml-configuration-file)) tells LGTM to use Python 3 analysis.

(Full disclosure: I'm on the LGTM.com team)